### PR TITLE
Fixed skill icons scale bug (#1)

### DIFF
--- a/app/common/SkillList.tsx
+++ b/app/common/SkillList.tsx
@@ -10,13 +10,13 @@ interface SkillListProps {
 const SkillList: React.FC<SkillListProps> = ({ src, skill }) => {
     return (
         <span className="flex items-center gap-[5px] p-2 md:px-3 lg:px-4 rounded-lg mx-1 group">
-            <div className="relative overflow-hidden">
+            <div className="relative w-4 md:w-[18px] lg:w-5 h-4 md:h-[18px] lg:h-5 flex items-center justify-center overflow-visible">
                 <Image 
                     src={src} 
                     alt={`${skill} icon`} 
                     width={20} 
                     height={20} 
-                    className="w-4 md:w-[18px] lg:w-5 transition-transform duration-400 group-hover:scale-[1.2] group-hover:rotate-[5deg]" 
+                    className="w-full h-full transition-transform duration-400 group-hover:scale-[1.2] group-hover:rotate-[5deg]" 
                 />
             </div>
             <p className="text-sm md:text-base lg:text-lg">{skill}</p>


### PR DESCRIPTION
Changed overflow-hidden to overflow-visible to allow the icon to scale outside its container without being cut off
![image](https://github.com/user-attachments/assets/4dc33343-cbef-4e70-999d-bf529601ddfb)

Solved bug #1 
